### PR TITLE
Title: "[hotfix] statistic에서 index 없앰"

### DIFF
--- a/src/modules/survey/statistic/StatisticsPage.tsx
+++ b/src/modules/survey/statistic/StatisticsPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -342,7 +343,7 @@ export default function StatisticsPage() {
               <CardContent>
                 <Box>
                   <Typography sx={styles.componentText}>
-                    {index + 1} . {itemsForQuestion[0].surveyQuestionTitle}
+                    {itemsForQuestion[0].surveyQuestionTitle}
                   </Typography>
 
                   <Typography sx={styles.surveyInfo}>
@@ -495,7 +496,6 @@ export default function StatisticsPage() {
           </Box>
         );
       })}
-
       <Box sx={styles.card}>
         <Card sx={styles.cardTitle}>
           {' '}


### PR DESCRIPTION
**내용**
ui상으로 통계 페이지에서 각 문항에 index가 표기 되는 부분 제거

Issue: #225 